### PR TITLE
Generate dnsdock alias list from network aliases

### DIFF
--- a/docker-compose/src/main/java/com/github/swissquote/carnotzet/runtime/docker/compose/DockerComposeRuntime.java
+++ b/docker-compose/src/main/java/com/github/swissquote/carnotzet/runtime/docker/compose/DockerComposeRuntime.java
@@ -97,7 +97,7 @@ public class DockerComposeRuntime implements ContainerOrchestrationRuntime {
 			if (module.getLabels() != null) {
 				labels.putAll(module.getLabels());
 			}
-			labels.put("com.dnsdock.alias", instanceId + "." + module.getName() + ".docker");
+			labels.put("com.dnsdock.alias", networkAliases.stream().collect(Collectors.joining(",")));
 			labels.put("carnotzet.instance.id", instanceId);
 			labels.put("carnotzet.module.name", module.getName());
 			labels.put("carnotzet.top.level.module.name", carnotzet.getTopLevelModuleName());


### PR DESCRIPTION
In order to have consistency between dnsdock configuration and network aliases configuration, we generate the list of dns dock aliases from the network aliases.