### PR TITLE
Make it possible to pull images only if the repository version is more recent than the local version

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -52,6 +52,31 @@
 			<artifactId>jansi</artifactId>
 			<version>1.14</version>
 		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>${jackson.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.datatype</groupId>
+			<artifactId>jackson-datatype-jsr310</artifactId>
+			<version>${jackson.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.glassfish.jersey.core</groupId>
+			<artifactId>jersey-client</artifactId>
+			<version>${jersey.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.glassfish.jersey.ext</groupId>
+			<artifactId>jersey-proxy-client</artifactId>
+			<version>${jersey.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.glassfish.jersey.media</groupId>
+			<artifactId>jersey-media-json-jackson</artifactId>
+			<version>${jersey.version}</version>
+		</dependency>
 
 		<!-- Tests -->
 		<dependency>

--- a/core/src/main/java/com/github/swissquote/carnotzet/core/Carnotzet.java
+++ b/core/src/main/java/com/github/swissquote/carnotzet/core/Carnotzet.java
@@ -16,6 +16,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -25,9 +26,10 @@ import java.util.stream.Collectors;
 import com.github.swissquote.carnotzet.core.maven.CarnotzetModuleCoordinates;
 import com.github.swissquote.carnotzet.core.maven.MavenDependencyResolver;
 import com.github.swissquote.carnotzet.core.maven.ResourcesManager;
-
 import com.google.common.base.Strings;
+
 import lombok.Getter;
+import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -108,6 +110,10 @@ public class Carnotzet {
 			}
 		}
 		return modules;
+	}
+
+	public Optional<CarnotzetModule> getModule(@NonNull String moduleName) {
+		return getModules().stream().filter(module -> moduleName.equals(module.getName())).findFirst();
 	}
 
 	private List<CarnotzetModule> configureModules(List<CarnotzetModule> modules) {

--- a/core/src/main/java/com/github/swissquote/carnotzet/core/CarnotzetConfig.java
+++ b/core/src/main/java/com/github/swissquote/carnotzet/core/CarnotzetConfig.java
@@ -10,7 +10,7 @@ import lombok.NonNull;
 import lombok.Value;
 
 @Value
-@Builder
+@Builder(toBuilder = true)
 public class CarnotzetConfig {
 
 	@NonNull

--- a/core/src/main/java/com/github/swissquote/carnotzet/core/config/PropertyUtils.java
+++ b/core/src/main/java/com/github/swissquote/carnotzet/core/config/PropertyUtils.java
@@ -13,25 +13,32 @@ import java.util.stream.Collectors;
 public final class PropertyUtils {
 
 	/**
+	 * Utility classes cannot have constructors.
+	 */
+	private PropertyUtils() {
+	}
+
+	/**
 	 * Inspired by java.utils.Properties#store0, but sorts lines in lexicographical order and doesn't output comments in the file
 	 */
 	public static void outputCleanPropFile(Properties props, Path path) throws IOException {
-		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(Files.newOutputStream(path), "8859_1"));
-		synchronized (props) {
-			List<String> keys = Collections.list(props.keys()).stream().map(Object::toString).collect(Collectors.toList());
-			Collections.sort(keys);
-			for (String key : keys) {
-				String val = (String) props.get(key);
-				key = saveConvert(key, true, true);
-				/* No need to escape embedded and trailing spaces for value, hence
-				 * pass false to flag.
-                 */
-				val = saveConvert(val, false, true);
-				bw.write(key + "=" + val);
-				bw.newLine();
+		try (BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(Files.newOutputStream(path), "8859_1"))) {
+			synchronized (props) {
+				List<String> keys = Collections.list(props.keys()).stream().map(Object::toString).collect(Collectors.toList());
+				Collections.sort(keys);
+				for (String key : keys) {
+					String val = (String) props.get(key);
+					key = saveConvert(key, true, true);
+					/* No need to escape embedded and trailing spaces for value, hence
+					 * pass false to flag.
+					 */
+					val = saveConvert(val, false, true);
+					bw.write(key + "=" + val);
+					bw.newLine();
+				}
 			}
+			bw.flush();
 		}
-		bw.flush();
 	}
 
 	/**
@@ -112,13 +119,13 @@ public final class PropertyUtils {
 	 * @param nibble the nibble to convert.
 	 */
 	private static char toHex(int nibble) {
-		return hexDigit[(nibble & 0xF)];
+		return HEX_DIGIT[(nibble & 0xF)];
 	}
 
 	/**
 	 * A table of hex digits
 	 */
-	private static final char[] hexDigit = {
+	private static final char[] HEX_DIGIT = {
 			'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'
 	};
 

--- a/core/src/main/java/com/github/swissquote/carnotzet/core/docker/registry/Auth.java
+++ b/core/src/main/java/com/github/swissquote/carnotzet/core/docker/registry/Auth.java
@@ -1,0 +1,12 @@
+package com.github.swissquote.carnotzet.core.docker.registry;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import lombok.Data;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Auth {
+
+	private String auth;
+}

--- a/core/src/main/java/com/github/swissquote/carnotzet/core/docker/registry/ContainerImageConfig.java
+++ b/core/src/main/java/com/github/swissquote/carnotzet/core/docker/registry/ContainerImageConfig.java
@@ -1,0 +1,68 @@
+package com.github.swissquote.carnotzet.core.docker.registry;
+
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Data;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ContainerImageConfig {
+
+	@JsonProperty("Hostname")
+	private String hostname;
+
+	@JsonProperty("Domainname")
+	private String domainname;
+
+	@JsonProperty("User")
+	private String user;
+
+	@JsonProperty("AttachStdin")
+	private Boolean attachStdin;
+
+	@JsonProperty("AttachStdout")
+	private Boolean attachStdout;
+
+	@JsonProperty("AttachStderr")
+	private Boolean attachStderr;
+
+	@JsonProperty("ExposedPorts")
+	private Map<String, EmptyObject> exposedPorts;
+
+	@JsonProperty("Tty")
+	private Boolean tty;
+
+	@JsonProperty("OpenStdin")
+	private Boolean openStdin;
+
+	@JsonProperty("StdinOnce")
+	private Boolean stdinOnce;
+
+	@JsonProperty("Env")
+	private List<String> env;
+
+	@JsonProperty("Cmd")
+	private List<String> cmd;
+
+	@JsonProperty("Healthcheck")
+	private ContainerImageHealthcheck healthcheck;
+
+	@JsonProperty("ArgsEscaped")
+	private Boolean argsEscaped;
+
+	@JsonProperty("Image")
+	private String image;
+
+	@JsonProperty("WorkingDir")
+	private String workingDir;
+
+	@JsonProperty("Entrypoint")
+	private List<String> entrypoint;
+
+	@JsonProperty("Labels")
+	private Map<String, String> labels;
+}

--- a/core/src/main/java/com/github/swissquote/carnotzet/core/docker/registry/ContainerImageFilesystem.java
+++ b/core/src/main/java/com/github/swissquote/carnotzet/core/docker/registry/ContainerImageFilesystem.java
@@ -1,0 +1,19 @@
+package com.github.swissquote.carnotzet.core.docker.registry;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Data;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ContainerImageFilesystem {
+
+	@JsonProperty("type")
+	private String cmd;
+
+	@JsonProperty("diff_ids")
+	private List<String> entrypoint;
+}

--- a/core/src/main/java/com/github/swissquote/carnotzet/core/docker/registry/ContainerImageHealthcheck.java
+++ b/core/src/main/java/com/github/swissquote/carnotzet/core/docker/registry/ContainerImageHealthcheck.java
@@ -1,0 +1,19 @@
+package com.github.swissquote.carnotzet.core.docker.registry;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Data;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ContainerImageHealthcheck {
+
+	@JsonProperty("Test")
+	private List<String> test;
+
+	@JsonProperty("Interval")
+	private Long interval;
+}

--- a/core/src/main/java/com/github/swissquote/carnotzet/core/docker/registry/ContainerImageHistoryItem.java
+++ b/core/src/main/java/com/github/swissquote/carnotzet/core/docker/registry/ContainerImageHistoryItem.java
@@ -1,0 +1,21 @@
+package com.github.swissquote.carnotzet.core.docker.registry;
+
+import java.time.Instant;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Data;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ContainerImageHistoryItem {
+	@JsonProperty("created")
+	private Instant created;
+
+	@JsonProperty("created_by")
+	private String createdBy;
+
+	@JsonProperty(value = "empty_layer")
+	private boolean emptyLayer; // default value is false in the Json schema. As it happens, it is the same in java
+}

--- a/core/src/main/java/com/github/swissquote/carnotzet/core/docker/registry/ContainerImageHistoryItem.java
+++ b/core/src/main/java/com/github/swissquote/carnotzet/core/docker/registry/ContainerImageHistoryItem.java
@@ -1,6 +1,6 @@
 package com.github.swissquote.carnotzet.core.docker.registry;
 
-import java.time.Instant;
+import java.time.ZonedDateTime;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -11,7 +11,7 @@ import lombok.Data;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ContainerImageHistoryItem {
 	@JsonProperty("created")
-	private Instant created;
+	private ZonedDateTime created;
 
 	@JsonProperty("created_by")
 	private String createdBy;

--- a/core/src/main/java/com/github/swissquote/carnotzet/core/docker/registry/ContainerImageV1.java
+++ b/core/src/main/java/com/github/swissquote/carnotzet/core/docker/registry/ContainerImageV1.java
@@ -1,6 +1,6 @@
 package com.github.swissquote.carnotzet.core.docker.registry;
 
-import java.time.Instant;
+import java.time.ZonedDateTime;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -25,7 +25,7 @@ public class ContainerImageV1 {
 	private ContainerImageConfig containerConfig;
 
 	@JsonProperty("created")
-	private Instant created;
+	private ZonedDateTime created;
 
 	@JsonProperty("docker_version")
 	private String dockerVersion;

--- a/core/src/main/java/com/github/swissquote/carnotzet/core/docker/registry/ContainerImageV1.java
+++ b/core/src/main/java/com/github/swissquote/carnotzet/core/docker/registry/ContainerImageV1.java
@@ -1,0 +1,41 @@
+package com.github.swissquote.carnotzet.core.docker.registry;
+
+import java.time.Instant;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Data;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ContainerImageV1 {
+
+	@JsonProperty("architecture")
+	private String architecture;
+
+	@JsonProperty("config")
+	private ContainerImageConfig config;
+
+	@JsonProperty("container")
+	private String container;
+
+	@JsonProperty("container_config")
+	private ContainerImageConfig containerConfig;
+
+	@JsonProperty("created")
+	private Instant created;
+
+	@JsonProperty("docker_version")
+	private String dockerVersion;
+
+	@JsonProperty("history")
+	private List<ContainerImageHistoryItem> history;
+
+	@JsonProperty("os")
+	private String os;
+
+	@JsonProperty("rootfs")
+	private ContainerImageFilesystem rootfs;
+}

--- a/core/src/main/java/com/github/swissquote/carnotzet/core/docker/registry/DistributionManifestConfig.java
+++ b/core/src/main/java/com/github/swissquote/carnotzet/core/docker/registry/DistributionManifestConfig.java
@@ -1,0 +1,11 @@
+package com.github.swissquote.carnotzet.core.docker.registry;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import lombok.Data;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class DistributionManifestConfig {
+	private String digest;
+}

--- a/core/src/main/java/com/github/swissquote/carnotzet/core/docker/registry/DistributionManifestLayer.java
+++ b/core/src/main/java/com/github/swissquote/carnotzet/core/docker/registry/DistributionManifestLayer.java
@@ -1,0 +1,19 @@
+package com.github.swissquote.carnotzet.core.docker.registry;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Data;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class DistributionManifestLayer {
+	@JsonProperty("mediaType")
+	private String mediaType;
+
+	@JsonProperty("size")
+	private Long size;
+
+	@JsonProperty("digest")
+	private String digest;
+}

--- a/core/src/main/java/com/github/swissquote/carnotzet/core/docker/registry/DistributionManifestV2.java
+++ b/core/src/main/java/com/github/swissquote/carnotzet/core/docker/registry/DistributionManifestV2.java
@@ -1,0 +1,27 @@
+package com.github.swissquote.carnotzet.core.docker.registry;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Data;
+
+/**
+ * Can be a distribution manifest or an image manifest
+ */
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class DistributionManifestV2 {
+	@JsonProperty("config")
+	private DistributionManifestConfig config;
+
+	@JsonProperty("schemaVersion")
+	private Integer schemaVersion;
+
+	@JsonProperty("mediaType")
+	private String mediaType;
+
+	@JsonProperty("layers")
+	private List<DistributionManifestLayer> layers;
+}

--- a/core/src/main/java/com/github/swissquote/carnotzet/core/docker/registry/DockerConfig.java
+++ b/core/src/main/java/com/github/swissquote/carnotzet/core/docker/registry/DockerConfig.java
@@ -1,0 +1,48 @@
+package com.github.swissquote.carnotzet.core.docker.registry;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * For json deserialization
+ */
+@Slf4j
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class DockerConfig {
+
+	private Map<String, Auth> auths = new HashMap<>();
+
+	public String getAuthFor(String registry) {
+		return auths.get(registry).getAuth();
+	}
+
+	public static DockerConfig fromEnv() {
+		Path configJson = Paths.get(System.getProperty("user.home")).resolve(".docker/config.json");
+
+		if (!configJson.toFile().exists()) {
+			log.warn("No registry auth found in [{}]", configJson);
+			return new DockerConfig();
+		}
+
+		ObjectMapper objectMapper = new ObjectMapper();
+		try {
+			return objectMapper.readValue(Files.readAllBytes(configJson), DockerConfig.class);
+		}
+		catch (IOException e) {
+			throw new UncheckedIOException(e);
+		}
+	}
+
+}

--- a/core/src/main/java/com/github/swissquote/carnotzet/core/docker/registry/DockerRegistry.java
+++ b/core/src/main/java/com/github/swissquote/carnotzet/core/docker/registry/DockerRegistry.java
@@ -1,0 +1,84 @@
+package com.github.swissquote.carnotzet.core.docker.registry;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+
+import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature;
+import org.glassfish.jersey.client.proxy.WebResourceFactory;
+import org.glassfish.jersey.jackson.JacksonFeature;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.jaxrs.cfg.Annotations;
+import com.fasterxml.jackson.jaxrs.json.JacksonJaxbJsonProvider;
+import com.github.swissquote.carnotzet.core.CarnotzetDefinitionException;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class DockerRegistry {
+
+	public static final DockerRegistry INSTANCE = new DockerRegistry();
+
+	private final DockerConfig config = DockerConfig.fromEnv();
+	private final Map<String, RegistryEndpoints> proxyClients = new HashMap<>();
+
+	public ImageMetaData getImageMetaData(ImageRef imageRef) {
+		DistributionManifestV2 di = getDistributionManifest(imageRef);
+		ContainerImageV1 im = getImageManifest(imageRef, di);
+		return new ImageMetaData(di, im);
+	}
+
+	private DistributionManifestV2 getDistributionManifest(ImageRef imageRef) {
+		try {
+			RegistryEndpoints registry = getRegistryClient(imageRef);
+			return registry.getDistributionManifest(imageRef.getImageName(), imageRef.getTag());
+		}
+		catch (Exception e) {
+			throw new CarnotzetDefinitionException("Could not fetch distribution manifest of [" + imageRef + "]", e);
+		}
+	}
+
+	private ContainerImageV1 getImageManifest(ImageRef imageRef, DistributionManifestV2 distributionManifest) {
+		if (distributionManifest.getConfig() == null || distributionManifest.getConfig().getDigest() == null) {
+			throw new CarnotzetDefinitionException("Distribution manifest of images [" + imageRef + " does not contain digest of image");
+		}
+
+		try {
+			RegistryEndpoints registry = getRegistryClient(imageRef);
+			return registry.getImageManifest(imageRef.getImageName(), distributionManifest.getConfig().getDigest());
+		}
+		catch (Exception e) {
+			throw new CarnotzetDefinitionException("Could not fetch config manifest of image [" + imageRef + "]", e);
+		}
+	}
+
+	private RegistryEndpoints getRegistryClient(ImageRef imageRef) {
+		if (!proxyClients.containsKey(imageRef.getRegistryUrl())) {
+
+			ObjectMapper mapper = new ObjectMapper();
+			mapper.registerModule(new JavaTimeModule());
+
+			Client client = ClientBuilder.newClient()
+					.register(new JacksonJaxbJsonProvider(mapper, new Annotations[] {Annotations.JACKSON}))
+					.register(JacksonFeature.class);
+			String auth = config.getAuthFor(imageRef.getRegistryName());
+			if (auth != null) {
+				String[] credentials = new String(Base64.getDecoder().decode(auth), StandardCharsets.UTF_8).split(":");
+				client.register(HttpAuthenticationFeature.basicBuilder().credentials(credentials[0], credentials[1]));
+				{
+				}
+				WebTarget webTarget = client.target(imageRef.getRegistryUrl());
+				proxyClients.put(imageRef.getRegistryUrl(), WebResourceFactory.newResource(RegistryEndpoints.class, webTarget));
+			}
+		}
+		return proxyClients.get(imageRef.getRegistryUrl());
+	}
+
+}

--- a/core/src/main/java/com/github/swissquote/carnotzet/core/docker/registry/EmptyObject.java
+++ b/core/src/main/java/com/github/swissquote/carnotzet/core/docker/registry/EmptyObject.java
@@ -1,0 +1,19 @@
+package com.github.swissquote.carnotzet.core.docker.registry;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import lombok.Data;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class EmptyObject {
+	/**
+	 * From https://github.com/opencontainers/image-spec/blob/master/config.md :
+	 *
+	 * This JSON structure value is unusual because it is a direct JSON serialization of
+	 * the Go type map[string]struct{} and is represented in JSON as an object
+	 * mapping its keys to an empty object.
+	 *
+	 * This is what happens when you think API in the wrong language I guess...
+	 */
+}

--- a/core/src/main/java/com/github/swissquote/carnotzet/core/docker/registry/ImageMetaData.java
+++ b/core/src/main/java/com/github/swissquote/carnotzet/core/docker/registry/ImageMetaData.java
@@ -1,0 +1,9 @@
+package com.github.swissquote.carnotzet.core.docker.registry;
+
+import lombok.Value;
+
+@Value
+public class ImageMetaData {
+	private final DistributionManifestV2 distributionManifest;
+	private final ContainerImageV1 containerImage;
+}

--- a/core/src/main/java/com/github/swissquote/carnotzet/core/docker/registry/ImageRef.java
+++ b/core/src/main/java/com/github/swissquote/carnotzet/core/docker/registry/ImageRef.java
@@ -1,0 +1,134 @@
+/*-
+ * -\-\-
+ * docker-client
+ * --
+ * Copyright (C) 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.github.swissquote.carnotzet.core.docker.registry;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.MoreObjects;
+
+public class ImageRef {
+
+	private static final String DEFAULT_REGISTRY = "docker.io";
+	private static final String DEFAULT_REGISTRY_URL = "https://index.docker.io/v1/";
+	private static final String DEFAULT_TAG = "latest";
+
+	private final String registryUrl;
+	private final String registry;
+	private final String image;
+	private final String tag;
+
+	public ImageRef(final String image) {
+		final int lastAt = image.lastIndexOf('@');
+		final int lastColon = image.lastIndexOf(':');
+		if (lastAt >= 0) {
+			this.image = image;
+			this.tag = null;
+		} else if (lastColon < 0) {
+			this.image = image;
+			this.tag = null;
+		} else {
+			final String tag = image.substring(lastColon + 1);
+			if (tag.indexOf('/') < 0) {
+				this.image = image.substring(0, lastColon);
+				this.tag = tag;
+			} else {
+				this.image = image;
+				this.tag = null;
+			}
+		}
+		final String[] parts = image.split("/", 2);
+		if (parts.length > 1 && isRegistry(parts[0])) {
+			this.registry = parts[0];
+			this.registryUrl = parseRegistryUrl(parts[0]);
+		} else {
+			this.registry = DEFAULT_REGISTRY;
+			this.registryUrl = DEFAULT_REGISTRY_URL;
+		}
+	}
+
+	private static boolean isRegistry(String part) {
+		return part.contains(".");
+	}
+
+	public String getImage() {
+		return image;
+	}
+
+	/**
+	 * The image tag, or null if not set.
+	 */
+	public String getTag() {
+		if (tag == null) {
+			return DEFAULT_TAG;
+		}
+		return tag;
+	}
+
+	/**
+	 * Hostname/ip address and port of the registry.
+	 */
+	public String getRegistryName() {
+		return registry;
+	}
+
+	/**
+	 * Registry URL.
+	 */
+	public String getRegistryUrl() {
+		return registryUrl;
+	}
+
+	@Override
+	public String toString() {
+		return MoreObjects.toStringHelper(this)
+				.add("registry", registry)
+				.add("image", image)
+				.add("tag", tag)
+				.toString();
+	}
+
+	/**
+	 * Return registry server address given first part of image.
+	 */
+	@VisibleForTesting
+	static String parseRegistryUrl(final String url) {
+		if ("docker.io".equals(url) || "index.docker.io".equals(url)) {
+			return DEFAULT_REGISTRY_URL;
+		} else if (url.matches("(^|(\\w+)\\.)gcr\\.io$") || "gcr.kubernetes.io".equals(url)) {
+			// GCR uses https
+			return "https://" + url;
+		} else if ("quay.io".equals(url)) {
+			// Quay doesn't use any protocol in credentials file
+			return "quay.io";
+		} else if (!url.contains("http://") && !url.contains("https://")) {
+			// Assume https
+			return "https://" + url;
+		} else {
+			return url;
+		}
+	}
+
+	public String getImageName() {
+		if (image.indexOf('/') > 0) {
+			return image.split("/")[1];
+		}
+		return image;
+	}
+}

--- a/core/src/main/java/com/github/swissquote/carnotzet/core/docker/registry/RegistryEndpoints.java
+++ b/core/src/main/java/com/github/swissquote/carnotzet/core/docker/registry/RegistryEndpoints.java
@@ -1,0 +1,29 @@
+package com.github.swissquote.carnotzet.core.docker.registry;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+
+/**
+ * Docker registry V2 endpoints
+ */
+@Path("v2")
+public interface RegistryEndpoints {
+
+	@GET
+	@Path("{name}/manifests/{reference}")
+	@Produces("application/vnd.docker.distribution.manifest.v2+json")
+	DistributionManifestV2 getDistributionManifest(@PathParam("name") String name, @PathParam("reference") String reference);
+
+	@GET
+	@Path("{name}/manifests/{reference}")
+	@Produces("application/vnd.docker.container.image.v1+json")
+	ContainerImageV1 getImageManifest(@PathParam("name") String name, @PathParam("reference") String reference);
+
+	@GET
+	@Path("{name}/blobs/{digest}")
+		// Could not be an imageconfig if a tgz layer is requested.
+	DistributionManifestConfig getLayer(@PathParam("name") String name, @PathParam("digest") String digest);
+
+}

--- a/core/src/main/java/com/github/swissquote/carnotzet/core/runtime/api/ContainerOrchestrationRuntime.java
+++ b/core/src/main/java/com/github/swissquote/carnotzet/core/runtime/api/ContainerOrchestrationRuntime.java
@@ -13,6 +13,7 @@ public interface ContainerOrchestrationRuntime {
 
 	/**
 	 * Start an application
+	 *
 	 * @param service the application to start
 	 */
 	void start(String service);
@@ -29,6 +30,7 @@ public interface ContainerOrchestrationRuntime {
 
 	/**
 	 * Stop an application
+	 *
 	 * @param service to stop
 	 */
 	void stop(String service);
@@ -40,6 +42,7 @@ public interface ContainerOrchestrationRuntime {
 
 	/**
 	 * Delete resources for a given service
+	 *
 	 * @param service to clean
 	 */
 	void clean(String service);
@@ -51,29 +54,56 @@ public interface ContainerOrchestrationRuntime {
 
 	/**
 	 * Spawn an interactive shell inside the given service's container
+	 *
 	 * @param container to open the shell into
 	 */
 	void shell(Container container);
 
 	/**
-	 * Pull all docker images used in this environment
+	 * Pull all docker images used in this environment. If there is any local image with a tag that matches the pulled images, the local
+	 * tag will be overridden and point to the freshly pushed images.
+	 * Equivalent to calling pull(true).
 	 */
 	void pull();
 
 	/**
-	 * Pull a docker image used in this environment
+	 * Pull all docker images used in this environment unless the force parameter is set to false and local images are more recent than
+	 * the corresponding images on the remote repository. Calling pull(false) will make sure that the most recent version of all images is
+	 * available locally after this method returns.
+	 *
+	 * @param force true overrides the local image if it exists, false only overrides it if the registry image is more recent
+	 */
+	void pull(boolean force);
+
+	/**
+	 * Pull a docker image used in this environment. If there is any local image with a tag that matches the pulled image, the local
+	 * tag will be overridden and point to the freshly pushed image.
+	 * Equivalent to calling pull(service, true).
+	 *
 	 * @param service to pull
 	 */
 	void pull(String service);
 
 	/**
+	 * Pull a docker image used in this environment	unless the force parameter is set to false and the local image is more recent than
+	 * the corresponding image on the remote repository. Calling pull(service, false) will make sure that the most recent version of the
+	 * image is available locally after this method returns.
+	 *
+	 * @param service to pull
+	 * @param force   true overrides the local image if it exists, false only overrides it if the registry image is more recent
+	 */
+	void pull(String service, boolean force);
+
+	/**
 	 * List containers managed by this
+	 *
 	 * @return the list of all containers for this environment
 	 */
 	List<Container> getContainers();
 
 	/**
 	 * get details about a specific container
+	 *
 	 * @param serviceName in the environment
 	 * @return details about the container
 	 */
@@ -83,6 +113,7 @@ public interface ContainerOrchestrationRuntime {
 	 * Register a listener for log events.
 	 * log event will be sent asynchronously to the listener.
 	 * Can be called before or after start()
+	 *
 	 * @param listener to register
 	 */
 	void registerLogListener(LogListener listener);

--- a/core/src/main/java/com/github/swissquote/carnotzet/core/runtime/api/ContainerOrchestrationRuntime.java
+++ b/core/src/main/java/com/github/swissquote/carnotzet/core/runtime/api/ContainerOrchestrationRuntime.java
@@ -60,39 +60,35 @@ public interface ContainerOrchestrationRuntime {
 	void shell(Container container);
 
 	/**
-	 * Pull all docker images used in this environment. If there is any local image with a tag that matches the pulled images, the local
+	 * Pulls all docker images used in this environment. If there is any local image with a tag that matches the pulled images, the local
 	 * tag will be overridden and point to the freshly pushed images.
-	 * Equivalent to calling pull(true).
+	 * Equivalent to calling pull(PullPolicy.ALWAYS).
 	 */
 	void pull();
 
 	/**
-	 * Pull all docker images used in this environment unless the force parameter is set to false and local images are more recent than
-	 * the corresponding images on the remote repository. Calling pull(false) will make sure that the most recent version of all images is
-	 * available locally after this method returns.
+	 * Pulls all docker images used in this environment according to the rules set by the specified PullPolicy.
 	 *
-	 * @param force true overrides the local image if it exists, false only overrides it if the registry image is more recent
+	 * @param policy decides whether an image must be pulled or not
 	 */
-	void pull(boolean force);
+	void pull(PullPolicy policy);
 
 	/**
-	 * Pull a docker image used in this environment. If there is any local image with a tag that matches the pulled image, the local
+	 * Pulls a single docker image used in this environment. If there is any local image with a tag that matches the pulled image, the local
 	 * tag will be overridden and point to the freshly pushed image.
-	 * Equivalent to calling pull(service, true).
+	 * Equivalent to calling pull(service, PullPolicy.ALWAYS).
 	 *
-	 * @param service to pull
+	 * @param service the name of the service whose docker image to be pulled
 	 */
 	void pull(String service);
 
 	/**
-	 * Pull a docker image used in this environment	unless the force parameter is set to false and the local image is more recent than
-	 * the corresponding image on the remote repository. Calling pull(service, false) will make sure that the most recent version of the
-	 * image is available locally after this method returns.
+	 * Pulls a single docker image used in this environment	according to the rules set by the specified PullPolicy.
 	 *
-	 * @param service to pull
-	 * @param force   true overrides the local image if it exists, false only overrides it if the registry image is more recent
+	 * @param service the name of the service whose docker image to be pulled
+	 * @param policy  decides whether an image must be pulled or not
 	 */
-	void pull(String service, boolean force);
+	void pull(String service, PullPolicy policy);
 
 	/**
 	 * List containers managed by this

--- a/core/src/main/java/com/github/swissquote/carnotzet/core/runtime/api/PullPolicy.java
+++ b/core/src/main/java/com/github/swissquote/carnotzet/core/runtime/api/PullPolicy.java
@@ -79,7 +79,7 @@ public interface PullPolicy {
 			}
 
 			// Pull if registry image is newer.
-			return localImageCreated.isBefore(registryImageMetadata.getContainerImage().getCreated());
+			return localImageCreated.isBefore(registryImageMetadata.getContainerImage().getCreated().toInstant());
 		}
 
 		@Override

--- a/core/src/main/java/com/github/swissquote/carnotzet/core/runtime/api/PullPolicy.java
+++ b/core/src/main/java/com/github/swissquote/carnotzet/core/runtime/api/PullPolicy.java
@@ -1,0 +1,124 @@
+package com.github.swissquote.carnotzet.core.runtime.api;
+
+import java.time.Instant;
+
+import javax.annotation.Nullable;
+
+import com.github.swissquote.carnotzet.core.CarnotzetModule;
+import com.github.swissquote.carnotzet.core.docker.registry.ImageMetaData;
+
+import lombok.NonNull;
+
+public interface PullPolicy {
+
+	/**
+	 * Always pulls registry images, disregarding the state of the local image. This policy will override any local image for that module.
+	 */
+	PullPolicy ALWAYS = new PullPolicy() {
+		@Override
+		public boolean shouldPullImage(CarnotzetModule module,
+				@Nullable Instant localImageCreated,
+				@Nullable ImageMetaData registryImageMetadata) {
+			return true;
+		}
+
+		@Override
+		public boolean requiresLocalMetadata() {
+			return false;
+		}
+
+		@Override
+		public boolean requiresRegistryMetadata() {
+			return false;
+		}
+	};
+
+	/**
+	 * Only pulls if there is no local image for the carnotzet module. This policy will fill in missing images, but will never override any
+	 * local image/tags.
+	 */
+	PullPolicy IF_LOCAL_IMAGE_ABSENT = new PullPolicy() {
+		@Override
+		public boolean shouldPullImage(CarnotzetModule module,
+				@Nullable Instant localImageCreated,
+				@Nullable ImageMetaData registryImageMetadata) {
+			return false;
+		}
+
+		@Override
+		public boolean requiresLocalMetadata() {
+			return true;
+		}
+
+		@Override
+		public boolean requiresRegistryMetadata() {
+			return false;
+		}
+	};
+
+	/**
+	 * Only pulls if the image in the remote registry has been created more recently than the local image.
+	 * - If there is no local image, the registry image will be pulled.
+	 * - If there is no matching image on the registry but there is a local image, nothing will be pulled and no errors will occur
+	 * - If there is no matching image locally or on the registry, then an error will occur.
+	 */
+	PullPolicy IF_REGISTRY_IMAGE_NEWER = new PullPolicy() {
+		@Override
+		public boolean shouldPullImage(CarnotzetModule module, @Nullable Instant localImageCreated,
+				@Nullable ImageMetaData registryImageMetadata) {
+			if (localImageCreated == null) {
+				// No local image
+				//  => We must always pull. It might cause failures if the image does not exist on the registry but that is on purpose
+				// because the user is doing something wrong if that happens.
+				return true;
+			}
+			if (registryImageMetadata == null || registryImageMetadata.getContainerImage().getCreated() == null) {
+				// Image doesn't exist on remote registry, or we cannot determine the timestamp
+				//  => There is nothing to pull
+				return false;
+			}
+
+			// Pull if registry image is newer.
+			return localImageCreated.isBefore(registryImageMetadata.getContainerImage().getCreated());
+		}
+
+		@Override
+		public boolean requiresLocalMetadata() {
+			return true;
+		}
+
+		@Override
+		public boolean requiresRegistryMetadata() {
+			return true;
+		}
+	};
+
+	/**
+	 * Checks if the registry image required by the specified Carnotzet module must be pulled.
+	 *
+	 * @param module                the module whose image might need to be pulled
+	 * @param localImageCreated     the timestamp at which the matching local image was created. null if there is no matching local image or
+	 *                              if requiresLocalMetadata() returned false.
+	 * @param registryImageMetadata the full metadata of the matching image on the remote registry. null if there is no such image on the
+	 *                              registry, or if requiresRegistryMetadata() returned false.
+	 */
+	boolean shouldPullImage(@NonNull CarnotzetModule module,
+			@Nullable Instant localImageCreated,
+			@Nullable ImageMetaData registryImageMetadata);
+
+	/**
+	 * Indicates if this policy requires the metadata of the local image to take its decision. If this method returns true, the metadata will
+	 * be fetched and passed to shouldPullImage(). If false, null will be passed to shouldPullImage().
+	 *
+	 * @return true to fetch metadata and pass it to shouldPullImage(), false to skip and pass null
+	 */
+	boolean requiresLocalMetadata();
+
+	/**
+	 * Indicates if this policy requires the metadata of the registry image to take its decision. If this method returns true, the metadata will
+	 * be fetched and passed to shouldPullImage(). If false, null will be passed to shouldPullImage().
+	 *
+	 * @return true to fetch metadata and pass it to shouldPullImage(), false to skip and pass null
+	 */
+	boolean requiresRegistryMetadata();
+}

--- a/docker-compose/src/main/java/com/github/swissquote/carnotzet/runtime/docker/compose/DockerComposeRuntime.java
+++ b/docker-compose/src/main/java/com/github/swissquote/carnotzet/runtime/docker/compose/DockerComposeRuntime.java
@@ -306,7 +306,7 @@ public class DockerComposeRuntime implements ContainerOrchestrationRuntime {
 		// Use docker inspect
 		String isoDatetime = runCommandAndCaptureOutput("docker", "inspect", "-f", "{{.Created}}", imageName);
 		try {
-			return Instant.from(DateTimeFormatter.ISO_INSTANT.parse(isoDatetime));
+			return Instant.from(DateTimeFormatter.ISO_ZONED_DATE_TIME.parse(isoDatetime));
 		}
 		catch (DateTimeException e) {
 			log.debug("Could not determine timestamp of local image [" + imageName + "], it probably doesn't exist", e);

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,8 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.version>3.2.5</maven.version>
+		<jersey.version>2.25.1</jersey.version>
+		<jackson.version>2.7.7</jackson.version>
 	</properties>
 
 	<build>


### PR DESCRIPTION
This is very useful when the maven dependency point to a SNAPSHOT version. During development, it often happens that an image generated through a SNAPSHOT version of a maven artifact is more recent on the local machine than it is on the remote repository, and that the developper does not want to push his updated image to the repository.