### PR TITLE
Also include jar resources for the top level module

### DIFF
--- a/core/src/main/java/com/github/swissquote/carnotzet/core/Carnotzet.java
+++ b/core/src/main/java/com/github/swissquote/carnotzet/core/Carnotzet.java
@@ -74,7 +74,7 @@ public class Carnotzet {
 		}
 
 		if (config.getClassifierIncludePattern() == null) {
-			this.classifierIncludePattern = null;
+			this.classifierIncludePattern = Pattern.compile("carnotzet");
 		} else {
 			this.classifierIncludePattern = Pattern.compile(config.getClassifierIncludePattern());
 		}

--- a/core/src/main/java/com/github/swissquote/carnotzet/core/CarnotzetConfig.java
+++ b/core/src/main/java/com/github/swissquote/carnotzet/core/CarnotzetConfig.java
@@ -30,10 +30,21 @@ public class CarnotzetConfig {
 	 * and filter out some dependencies.<br>
 	 * Must have exactly one capture group.<br>
 	 * The first capture group will be the name of the module.<br>
-	 * Dependencies which do not match the pattern will be ignored.<br>
+	 * Dependencies which do not match the pattern will be ignored, unless they use a
+	 * classifier that matches classifierIncludePattern.<br>
 	 * defaults to (.*)-cartnozet
 	 */
 	private final String moduleFilterPattern;
+
+	/**
+	 * If non-null, makes it possible for any artifact that doesn't match the <br>
+	 * moduleFilterPattern but matches the classifier include pattern to be be picked <br>
+	 * up in a Carnotzet.<br>
+	 * If a dependency matches the moduleFilterPattern, then classifierIncludePattern is ignored.<br>
+	 * The name of the module will be the artifactId of the dependency.<br>
+	 * defaults to null (i.e. disabled)
+	 */
+	private final String classifierIncludePattern;
 
 	/**
 	 * Registry used when inferring docker image name from artifact id (convention).<br>

--- a/core/src/main/java/com/github/swissquote/carnotzet/core/CarnotzetConfig.java
+++ b/core/src/main/java/com/github/swissquote/carnotzet/core/CarnotzetConfig.java
@@ -42,7 +42,7 @@ public class CarnotzetConfig {
 	 * up in a Carnotzet.<br>
 	 * If a dependency matches the moduleFilterPattern, then classifierIncludePattern is ignored.<br>
 	 * The name of the module will be the artifactId of the dependency.<br>
-	 * defaults to null (i.e. disabled)
+	 * defaults to "carnotzet"
 	 */
 	private final String classifierIncludePattern;
 

--- a/core/src/main/java/com/github/swissquote/carnotzet/core/maven/CarnotzetModuleCoordinates.java
+++ b/core/src/main/java/com/github/swissquote/carnotzet/core/maven/CarnotzetModuleCoordinates.java
@@ -1,17 +1,20 @@
 package com.github.swissquote.carnotzet.core.maven;
 
-import lombok.AllArgsConstructor;
-import lombok.Value;
-import org.apache.maven.model.Model;
-import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
-import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
-import com.github.swissquote.carnotzet.core.CarnotzetDefinitionException;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+
+import org.apache.maven.model.Model;
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+
+import com.github.swissquote.carnotzet.core.CarnotzetDefinitionException;
+
+import lombok.AllArgsConstructor;
+import lombok.NonNull;
+import lombok.Value;
 
 /**
  * Utility class that can be used to describe the root maven artifact for creating a carnotzet
@@ -20,11 +23,19 @@ import java.nio.file.Path;
 @AllArgsConstructor
 public class CarnotzetModuleCoordinates {
 
+	@NonNull
 	private final String groupId;
+	@NonNull
 	private final String artifactId;
+	@NonNull
 	private final String version;
+	private final String classifier;
 
-	public static CarnotzetModuleCoordinates fromPom(Path pom) {
+	public CarnotzetModuleCoordinates(String groupId, String artifactId, String version) {
+		this(groupId, artifactId, version, null);
+	}
+
+	public static CarnotzetModuleCoordinates fromPom(@NonNull Path pom) {
 		Model result;
 		try {
 			BufferedReader in = new BufferedReader(Files.newBufferedReader(pom, StandardCharsets.UTF_8));
@@ -42,7 +53,7 @@ public class CarnotzetModuleCoordinates {
 		if (version == null) {
 			version = result.getParent().getVersion();
 		}
-		return new CarnotzetModuleCoordinates(groupId, result.getArtifactId(), version);
+		return new CarnotzetModuleCoordinates(groupId, result.getArtifactId(), version, null);
 	}
 
 }

--- a/core/src/main/java/com/github/swissquote/carnotzet/core/maven/MavenDependencyResolver.java
+++ b/core/src/main/java/com/github/swissquote/carnotzet/core/maven/MavenDependencyResolver.java
@@ -82,7 +82,8 @@ public class MavenDependencyResolver {
 			CarnotzetModuleCoordinates coord = new CarnotzetModuleCoordinates(
 					artifact.getGroupId(),
 					artifact.getArtifactId(),
-					artifact.getVersion());
+					artifact.getVersion(),
+					artifact.getClassifier());
 			String name = moduleNameProvider.apply(coord);
 			if (name == null) {
 				continue;

--- a/core/src/main/java/com/github/swissquote/carnotzet/core/maven/MavenDependencyResolver.java
+++ b/core/src/main/java/com/github/swissquote/carnotzet/core/maven/MavenDependencyResolver.java
@@ -71,7 +71,15 @@ public class MavenDependencyResolver {
 	}
 
 	private void downloadJars(CarnotzetModuleCoordinates topLevelModuleId) {
-		String gav = topLevelModuleId.getGroupId() + ":" + topLevelModuleId.getArtifactId() + ":" + topLevelModuleId.getVersion();
+		// GAV are specified in this order:
+		// groupId:artifactId:packaging:classifier:version
+		// groupId:artifactId:packaging:version
+		String gav = topLevelModuleId.getGroupId() + ":" + topLevelModuleId.getArtifactId() + ":jar:";
+		if (topLevelModuleId.getClassifier() != null) {
+			gav += topLevelModuleId.getClassifier() + ":";
+		}
+		gav += topLevelModuleId.getVersion();
+
 		executeMavenBuild(Arrays.asList("org.apache.maven.plugins:maven-dependency-plugin:2.10:get -Dartifact=" + gav), null);
 	}
 
@@ -107,7 +115,15 @@ public class MavenDependencyResolver {
 				.resolve(artifact.getGroupId().replace(".", "/"))
 				.resolve(artifact.getArtifactId())
 				.resolve(artifact.getVersion())
-				.resolve(artifact.getArtifactId() + "-" + artifact.getVersion() + ".jar");
+				.resolve(getJarName(artifact));
+	}
+
+	private String getJarName(CarnotzetModuleCoordinates artifact) {
+		String jarName = artifact.getArtifactId() + "-" + artifact.getVersion();
+		if (artifact.getClassifier() != null) {
+			jarName += "-" + artifact.getClassifier();
+		}
+		return jarName + ".jar";
 	}
 
 	private Path getPomFile(CarnotzetModuleCoordinates artifact) {

--- a/core/src/main/java/com/github/swissquote/carnotzet/core/maven/ResourcesManager.java
+++ b/core/src/main/java/com/github/swissquote/carnotzet/core/maven/ResourcesManager.java
@@ -69,13 +69,16 @@ public class ResourcesManager {
 			String topLevelModuleName = modules.get(0).getTopLevelModuleName();
 
 			for (CarnotzetModule module : modules) {
+				// First copy all of the resources in the .jar of the module
+				copyModuleResources(module, expandedJars.resolve(module.getName()));
+
+				// If the module is the top level one, then we attempt to overwrite the files from the jar
+				// with fresher files coming directly from the source resource folder
 				if (module.getName().equals(topLevelModuleName)
 						&& topLevelModuleResourcesPath != null
 						&& topLevelModuleResourcesPath.toFile().exists()) {
 					FileUtils.copyDirectory(topLevelModuleResourcesPath.toFile(),
 							expandedJars.resolve(topLevelModuleName).toFile());
-				} else {
-					copyModuleResources(module, expandedJars.resolve(module.getName()));
 				}
 			}
 		}

--- a/docs/_docs/creating-your-own/dependencies.md
+++ b/docs/_docs/creating-your-own/dependencies.md
@@ -40,6 +40,11 @@ The environment will contain app1, redis and postgres:
 +-------+          +----------+
 ```
 
+By convention, Carnotzet will automatically create docker services for all dependencies of the root module whose
+artifactId ends with "-carnotzet". In some cases, suffixing all your dependencies artifact names with "-carnotzet"
+might not be convenient, or might be impossible. For those cases, Carnotzet will also include dependencies whose
+classifier is set to "carnotzet".
+
 Now if another team wants to import "app1" into the environment of "app2" (let's say it provides them a REST api, and we want 
 to avoid integration surprises so they don't want to mock it). This other team can depend on the app1 module and redis
  and postgres will transitively become part of their dev/test environment.

--- a/docs/_docs/user-guide/maven-plugin.md
+++ b/docs/_docs/user-guide/maven-plugin.md
@@ -66,7 +66,9 @@ zet:ps
   Lists the state of the carnotzet containers
 
 zet:pull
-  Pulls all images in the carnotzet from the docker image registry
+  Pulls all images in the carnotzet from the docker image registry.
+  use -Dpull.policy=... to pull only under certain conditions.
+  supported policies are (always|ifNotPresent|ifNewer)
 
 zet:restart
   restart all services for this carnotzet if -Dservice=... is passed, ony the


### PR DESCRIPTION
Currently all the resources for all Carnotzet modules are taken from their .jar files, except for the top level module. For the top level module, only the project's resource directory is taken into account (typically src/main/resources).

This is reasonable as it allows to update a carnotzet configuration without rebuilding the module. 

However it also means that all resources that are packaged into the top level module jar through other means, such as other maven plugins (maven-dependency-plugin, maven-assembly-plugin, etc...) are ignored when running a carnotzet from the top-level module (yet interestingly, they will be taken into account if that same module is used as a dependency for another one).

This pull request solves the problem by first including all the resources from the .jar of the top level module (which may be old), and then overwriting the jar contents with the contents of the resources directory (/src/main/resources), which are the freshest.