### PR TITLE
Replace jersey by resteasy to avoid maven dependency conflicts

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -53,6 +53,16 @@
 			<version>1.18</version>
 		</dependency>
 		<dependency>
+			<groupId>org.jboss.resteasy</groupId>
+			<artifactId>resteasy-client</artifactId>
+			<version>3.11.0.Final</version>
+		</dependency>
+		<dependency>
+			<groupId>org.jboss.resteasy</groupId>
+			<artifactId>resteasy-jackson2-provider</artifactId>
+			<version>3.11.0.Final</version>
+		</dependency>
+		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
 			<version>${jackson.version}</version>
@@ -61,16 +71,6 @@
 			<groupId>com.fasterxml.jackson.datatype</groupId>
 			<artifactId>jackson-datatype-jsr310</artifactId>
 			<version>${jackson.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.glassfish.jersey.core</groupId>
-			<artifactId>jersey-client</artifactId>
-			<version>${jersey.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.glassfish.jersey.media</groupId>
-			<artifactId>jersey-media-json-jackson</artifactId>
-			<version>${jersey.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>net.jodah</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,6 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.version>3.6.2</maven.version>
-		<jersey.version>2.25.1</jersey.version>
 		<jackson.version>2.10.1</jackson.version>
 	</properties>
 


### PR DESCRIPTION
The dependency on jersey that we use to download manifest json from docker registries often brings version conflicts in swissquote projects.
This replaces jersey by resteasy in carnotzet to avoid such issues.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/swissquote/carnotzet/133)
<!-- Reviewable:end -->
