### PR TITLE
Add configurable extension points for ContainerOrchestrationRuntime

### DIFF
--- a/core/src/main/java/com/github/swissquote/carnotzet/core/Carnotzet.java
+++ b/core/src/main/java/com/github/swissquote/carnotzet/core/Carnotzet.java
@@ -33,6 +33,7 @@ import com.google.common.base.Strings;
 
 import lombok.Getter;
 import lombok.NonNull;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -53,6 +54,7 @@ public class Carnotzet {
 	@Getter
 	private final Pattern classifierIncludePattern;
 
+	@Setter
 	private List<CarnotzetModule> modules;
 
 	private final MavenDependencyResolver resolver;
@@ -398,5 +400,6 @@ public class Carnotzet {
 		// nothing matches. Nothing to do
 		return null;
 	}
+
 
 }

--- a/core/src/main/java/com/github/swissquote/carnotzet/core/runtime/api/ContainerOrchestrationRuntime.java
+++ b/core/src/main/java/com/github/swissquote/carnotzet/core/runtime/api/ContainerOrchestrationRuntime.java
@@ -61,9 +61,8 @@ public interface ContainerOrchestrationRuntime {
 	void shell(Container container);
 
 	/**
-	 * Pulls all docker images used in this environment. If there is any local image with a tag that matches the pulled images, the local
-	 * tag will be overridden and point to the freshly pushed images.
-	 * Equivalent to calling pull(PullPolicy.ALWAYS).
+	 * Pulls all docker images used in this environment. If there is any local image with a tag that matches the pulled images, the local tag
+	 * will be overridden and point to the freshly pushed images. Equivalent to calling pull(PullPolicy.ALWAYS).
 	 */
 	void pull();
 
@@ -75,9 +74,8 @@ public interface ContainerOrchestrationRuntime {
 	void pull(PullPolicy policy);
 
 	/**
-	 * Pulls a single docker image used in this environment. If there is any local image with a tag that matches the pulled image, the local
-	 * tag will be overridden and point to the freshly pushed image.
-	 * Equivalent to calling pull(service, PullPolicy.ALWAYS).
+	 * Pulls a single docker image used in this environment. If there is any local image with a tag that matches the pulled image, the local tag
+	 * will be overridden and point to the freshly pushed image. Equivalent to calling pull(service, PullPolicy.ALWAYS).
 	 *
 	 * @param service the name of the service whose docker image to be pulled
 	 */
@@ -94,10 +92,10 @@ public interface ContainerOrchestrationRuntime {
 	/**
 	 * Executes a command in a service container
 	 *
-	 * @param service the name of the service in which's container to execute the command
-	 * @param timeout maximum execution time allowed
+	 * @param service     the name of the service in which's container to execute the command
+	 * @param timeout     maximum execution time allowed
 	 * @param timeoutUnit Time unit for the timeout
-	 * @param command The command to execute
+	 * @param command     The command to execute
 	 * @return The execution result
 	 */
 	ExecResult exec(String service, int timeout, TimeUnit timeoutUnit, String... command);
@@ -106,6 +104,7 @@ public interface ContainerOrchestrationRuntime {
 	 * List containers in the environment
 	 * <p>
 	 * If a service has multiple replicas, all containers will be returned
+	 *
 	 * @return the list of all containers for this environment
 	 */
 	List<Container> getContainers();
@@ -132,18 +131,23 @@ public interface ContainerOrchestrationRuntime {
 	 * get details about a specific container
 	 *
 	 * @param serviceName in the environment
-	 * @param number the replica number
+	 * @param number      the replica number
 	 * @return details about the container
 	 */
 	Container getContainer(String serviceName, int number);
 
 	/**
-	 * Register a listener for log events.
-	 * log event will be sent asynchronously to the listener.
-	 * Can be called before or after start()
+	 * Register a listener for log events. log event will be sent asynchronously to the listener. Can be called before or after start()
 	 *
 	 * @param listener to register
 	 */
 	void registerLogListener(LogListener listener);
+
+	/**
+	 * Returns the instance id of this runtime
+	 */
+	default String getInstanceId() {
+		throw new UnsupportedOperationException("getInstanceId is not implemented");
+	}
 
 }

--- a/core/src/main/java/com/github/swissquote/carnotzet/core/runtime/api/ContainerOrchestrationRuntimeExtension.java
+++ b/core/src/main/java/com/github/swissquote/carnotzet/core/runtime/api/ContainerOrchestrationRuntimeExtension.java
@@ -1,0 +1,43 @@
+package com.github.swissquote.carnotzet.core.runtime.api;
+
+import com.github.swissquote.carnotzet.core.Carnotzet;
+import com.github.swissquote.carnotzet.core.CarnotzetModule;
+
+/**
+ * Allows to perform modifications of the carnotzet using the runtime lifecycle
+ */
+public interface ContainerOrchestrationRuntimeExtension {
+
+	default CarnotzetModule beforeStart(CarnotzetModule module, ContainerOrchestrationRuntime runtime, Carnotzet carnotzet) {
+		return module;
+	}
+
+	default CarnotzetModule afterStart(CarnotzetModule module, ContainerOrchestrationRuntime runtime, Carnotzet carnotzet) {
+		return module;
+	}
+
+	default CarnotzetModule beforeStop(CarnotzetModule module, ContainerOrchestrationRuntime runtime, Carnotzet carnotzet) {
+		return module;
+	}
+
+	default CarnotzetModule afterStop(CarnotzetModule module, ContainerOrchestrationRuntime runtime, Carnotzet carnotzet) {
+		return module;
+	}
+
+	default CarnotzetModule beforeClean(CarnotzetModule module, ContainerOrchestrationRuntime runtime, Carnotzet carnotzet) {
+		return module;
+	}
+
+	default CarnotzetModule afterClean(CarnotzetModule module, ContainerOrchestrationRuntime runtime, Carnotzet carnotzet) {
+		return module;
+	}
+
+	default CarnotzetModule beforePull(CarnotzetModule module, ContainerOrchestrationRuntime runtime, Carnotzet carnotzet) {
+		return module;
+	}
+
+	default CarnotzetModule afterPull(CarnotzetModule module, ContainerOrchestrationRuntime runtime, Carnotzet carnotzet) {
+		return module;
+	}
+
+}

--- a/core/src/main/java/com/github/swissquote/carnotzet/core/runtime/spi/ContainerOrchestrationRuntimeDefaultExtensionsProvider.java
+++ b/core/src/main/java/com/github/swissquote/carnotzet/core/runtime/spi/ContainerOrchestrationRuntimeDefaultExtensionsProvider.java
@@ -1,0 +1,12 @@
+package com.github.swissquote.carnotzet.core.runtime.spi;
+
+import com.github.swissquote.carnotzet.core.runtime.api.ContainerOrchestrationRuntimeExtension;
+
+public interface ContainerOrchestrationRuntimeDefaultExtensionsProvider {
+
+	/**
+	 * Allows to provide runtime extensions that should be enabled by default in all runtimes if the list of extensions is not explicit.
+	 */
+	ContainerOrchestrationRuntimeExtension getDefaultExtension();
+
+}

--- a/docker-compose/src/main/java/com/github/swissquote/carnotzet/runtime/docker/compose/DockerComposeRuntime.java
+++ b/docker-compose/src/main/java/com/github/swissquote/carnotzet/runtime/docker/compose/DockerComposeRuntime.java
@@ -15,6 +15,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -22,6 +23,7 @@ import java.util.function.BiFunction;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.SystemUtils;
@@ -40,6 +42,7 @@ import com.github.swissquote.carnotzet.core.runtime.api.ContainerOrchestrationRu
 import com.github.swissquote.carnotzet.core.runtime.api.ExecResult;
 import com.github.swissquote.carnotzet.core.runtime.api.PullPolicy;
 import com.github.swissquote.carnotzet.core.runtime.log.LogListener;
+import com.github.swissquote.carnotzet.core.runtime.spi.ContainerOrchestrationRuntimeDefaultExtensionsProvider;
 import com.google.common.base.Strings;
 import com.google.common.io.Files;
 
@@ -75,7 +78,15 @@ public class DockerComposeRuntime implements ContainerOrchestrationRuntime {
 	}
 
 	public DockerComposeRuntime(Carnotzet carnotzet, String instanceId, CommandRunner commandRunner, Boolean shouldExposePorts) {
-		this(carnotzet, instanceId, commandRunner, shouldExposePorts, new ArrayList<>());
+		this(carnotzet, instanceId, commandRunner, shouldExposePorts, getDefaultRuntimeExtensions());
+	}
+
+	private static List<ContainerOrchestrationRuntimeExtension> getDefaultRuntimeExtensions() {
+		ServiceLoader<ContainerOrchestrationRuntimeDefaultExtensionsProvider> loader =
+				ServiceLoader.load(ContainerOrchestrationRuntimeDefaultExtensionsProvider.class);
+		return StreamSupport.stream(loader.spliterator(), false)
+				.map(ContainerOrchestrationRuntimeDefaultExtensionsProvider::getDefaultExtension)
+				.collect(Collectors.toList());
 	}
 
 	public DockerComposeRuntime(Carnotzet carnotzet, String instanceId, CommandRunner commandRunner, Boolean shouldExposePorts,

--- a/docker-compose/src/main/java/com/github/swissquote/carnotzet/runtime/docker/compose/DockerComposeRuntime.java
+++ b/docker-compose/src/main/java/com/github/swissquote/carnotzet/runtime/docker/compose/DockerComposeRuntime.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.BiFunction;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -35,6 +36,7 @@ import com.github.swissquote.carnotzet.core.runtime.CommandRunner;
 import com.github.swissquote.carnotzet.core.runtime.DefaultCommandRunner;
 import com.github.swissquote.carnotzet.core.runtime.api.Container;
 import com.github.swissquote.carnotzet.core.runtime.api.ContainerOrchestrationRuntime;
+import com.github.swissquote.carnotzet.core.runtime.api.ContainerOrchestrationRuntimeExtension;
 import com.github.swissquote.carnotzet.core.runtime.api.ExecResult;
 import com.github.swissquote.carnotzet.core.runtime.api.PullPolicy;
 import com.github.swissquote.carnotzet.core.runtime.log.LogListener;
@@ -50,7 +52,7 @@ public class DockerComposeRuntime implements ContainerOrchestrationRuntime {
 	private static final Pattern IP_ADDRESS_PATTERN = Pattern.compile(
 			"^(([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\.){3}([01]?\\d\\d?|2[0-4]\\d|25[0-5])$");
 
-	private final Carnotzet carnotzet;
+	private Carnotzet carnotzet;
 
 	private final String instanceId;
 
@@ -59,6 +61,8 @@ public class DockerComposeRuntime implements ContainerOrchestrationRuntime {
 	private final CommandRunner commandRunner;
 
 	private final Boolean shouldExposePorts;
+
+	private final List<ContainerOrchestrationRuntimeExtension> extensions;
 
 	public DockerComposeRuntime(Carnotzet carnotzet) {
 		this(carnotzet, carnotzet.getTopLevelModuleName());
@@ -71,6 +75,11 @@ public class DockerComposeRuntime implements ContainerOrchestrationRuntime {
 	}
 
 	public DockerComposeRuntime(Carnotzet carnotzet, String instanceId, CommandRunner commandRunner, Boolean shouldExposePorts) {
+		this(carnotzet, instanceId, commandRunner, shouldExposePorts, new ArrayList<>());
+	}
+
+	public DockerComposeRuntime(Carnotzet carnotzet, String instanceId, CommandRunner commandRunner, Boolean shouldExposePorts,
+			List<ContainerOrchestrationRuntimeExtension> extensions) {
 		this.carnotzet = carnotzet;
 		if (instanceId != null) {
 			this.instanceId = instanceId;
@@ -80,6 +89,8 @@ public class DockerComposeRuntime implements ContainerOrchestrationRuntime {
 		this.logManager = new DockerLogManager();
 		this.commandRunner = commandRunner;
 		this.shouldExposePorts = shouldExposePorts;
+		this.extensions = extensions;
+
 	}
 
 	public DockerComposeRuntime(Carnotzet carnotzet, String instanceId) {
@@ -101,8 +112,8 @@ public class DockerComposeRuntime implements ContainerOrchestrationRuntime {
 
 			serviceBuilder.image(module.getImageName());
 			serviceBuilder.volumes(module.getDockerVolumes());
-			serviceBuilder.entrypoint(DockerUtils.parseEntrypointOrCmd(module.getDockerEntrypoint()));
-			serviceBuilder.command(DockerUtils.parseEntrypointOrCmd(module.getDockerCmd()));
+			serviceBuilder.entrypoint(escapeEnvVars(DockerUtils.parseEntrypointOrCmd(module.getDockerEntrypoint())));
+			serviceBuilder.command(escapeEnvVars(DockerUtils.parseEntrypointOrCmd(module.getDockerCmd())));
 			serviceBuilder.shm_size(module.getDockerShmSize());
 			serviceBuilder.environment(module.getEnv());
 			serviceBuilder.env_file(module.getDockerEnvFiles());
@@ -161,6 +172,18 @@ public class DockerComposeRuntime implements ContainerOrchestrationRuntime {
 		log.debug(String.format("End build compose file for module %s", carnotzet.getConfig().getTopLevelModuleId()));
 	}
 
+	/**
+	 * If the entrypoint or command uses environment variables that are present inside the container, we don't want docker-compose to try to
+	 * interpolate them when docker-compose is run (the docker-compose process is run outside of the container and those variables don't exist).
+	 * <b>https://docs.docker.com/compose/compose-file/compose-file-v3/#variable-substitution</b>
+	 */
+	private List<String> escapeEnvVars(List<String> cmdOrEntryPoint) {
+		if (cmdOrEntryPoint == null) {
+			return null;
+		}
+		return cmdOrEntryPoint.stream().map(s -> s.replaceAll("\\$", "\\$\\$")).collect(Collectors.toList());
+	}
+
 	private Collection<String> lookUpCustomAliases(CarnotzetModule m) {
 		Set<String> result = new HashSet<>();
 		if (m.getProperties() != null && m.getProperties().containsKey("network.aliases")) {
@@ -185,17 +208,49 @@ public class DockerComposeRuntime implements ContainerOrchestrationRuntime {
 		return result;
 	}
 
+	private void invokeAllExtensions(BiFunction<ContainerOrchestrationRuntimeExtension, CarnotzetModule, CarnotzetModule> consumer) {
+		List<CarnotzetModule> modules = new ArrayList<>();
+		for (CarnotzetModule m : carnotzet.getModules()) {
+			CarnotzetModule modified = m;
+			for (ContainerOrchestrationRuntimeExtension extension : extensions) {
+				modified = consumer.apply(extension, modified);
+			}
+			modules.add(modified);
+		}
+
+		carnotzet.setModules(modules);
+	}
+
+	private void invokeAllExtensions(BiFunction<ContainerOrchestrationRuntimeExtension, CarnotzetModule, CarnotzetModule> consumer,
+			CarnotzetModule module) {
+		CarnotzetModule modified = module;
+		for (ContainerOrchestrationRuntimeExtension extension : extensions) {
+			modified = consumer.apply(extension, modified);
+		}
+		List<CarnotzetModule> modules = new ArrayList<>();
+		for (CarnotzetModule m : carnotzet.getModules()) {
+			if (m.getId().equals(modified.getId())) {
+				modules.add(modified);
+			} else {
+				modules.add(m);
+			}
+		}
+		carnotzet.setModules(modules);
+	}
+
 	@Override
 	public void start() {
+		Instant start = Instant.now();
+		invokeAllExtensions((e, m) -> e.beforeStart(m, this, this.carnotzet));
 		log.debug("Forcing update of docker-compose.yml before start");
 		computeDockerComposeFile();
-		Instant start = Instant.now();
 		carnotzet.getModules().stream().filter(this::shouldStartByDefault).forEach(m ->
 				runCommand("docker-compose", "-p", getDockerComposeProjectName(), "up", "-d",
 						"--scale", m.getServiceId() + "=" + m.getReplicas(), m.getServiceId())
 		);
 		ensureNetworkCommunicationIsPossible();
 		logManager.ensureCapturingLogs(start, getContainers());
+		invokeAllExtensions((e, m) -> e.afterStart(m, this, this.carnotzet));
 	}
 
 	private boolean shouldStartByDefault(CarnotzetModule m) {
@@ -221,10 +276,12 @@ public class DockerComposeRuntime implements ContainerOrchestrationRuntime {
 		computeDockerComposeFile();
 		for (CarnotzetModule carnotzetModule : resolveModules(services)) {
 			String service = carnotzetModule.getServiceId();
+			invokeAllExtensions((e, m) -> e.beforeStart(m, this, this.carnotzet), carnotzetModule);
 			Instant start = Instant.now();
 			runCommand("docker-compose", "-p", getDockerComposeProjectName(), "up", "-d", service);
 			ensureNetworkCommunicationIsPossible();
 			logManager.ensureCapturingLogs(start, Collections.singletonList(getContainer(service)));
+			invokeAllExtensions((e, m) -> e.afterStart(m, this, this.carnotzet), carnotzetModule);
 		}
 	}
 
@@ -264,16 +321,20 @@ public class DockerComposeRuntime implements ContainerOrchestrationRuntime {
 
 	@Override
 	public void stop() {
+		invokeAllExtensions((e, m) -> e.beforeStop(m, this, this.carnotzet));
 		ensureDockerComposeFileIsPresent();
 		runCommand("docker-compose", "-p", getDockerComposeProjectName(), "stop");
+		invokeAllExtensions((e, m) -> e.afterStop(m, this, this.carnotzet));
 	}
 
 	@Override
 	public void stop(String services) {
-		ensureDockerComposeFileIsPresent();
 		for (CarnotzetModule carnotzetModule : resolveModules(services)) {
 			String service = carnotzetModule.getServiceId();
+			invokeAllExtensions((e, m) -> e.beforeStop(m, this, this.carnotzet), carnotzetModule);
+			ensureDockerComposeFileIsPresent();
 			runCommand("docker-compose", "-p", getDockerComposeProjectName(), "stop", service);
+			invokeAllExtensions((e, m) -> e.afterStop(m, this, this.carnotzet), carnotzetModule);
 		}
 	}
 
@@ -285,6 +346,7 @@ public class DockerComposeRuntime implements ContainerOrchestrationRuntime {
 
 	@Override
 	public void clean() {
+		invokeAllExtensions((e, m) -> e.beforeClean(m, this, this.carnotzet));
 		ensureDockerComposeFileIsPresent();
 		runCommand("docker-compose", "-p", getDockerComposeProjectName(), "rm", "-f");
 		// The resources folder cannot be deleted while the sandbox is running on windows.
@@ -297,6 +359,7 @@ public class DockerComposeRuntime implements ContainerOrchestrationRuntime {
 				throw new UncheckedIOException(e);
 			}
 		}
+		invokeAllExtensions((e, m) -> e.afterClean(m, this, this.carnotzet));
 	}
 
 	@Override
@@ -321,8 +384,10 @@ public class DockerComposeRuntime implements ContainerOrchestrationRuntime {
 
 	@Override
 	public void pull(PullPolicy policy) {
+		invokeAllExtensions((e, m) -> e.beforePull(m, this, this.carnotzet));
 		// We need to check service by service if a newer version exists or not
 		carnotzet.getModules().forEach(module -> pull(module.getServiceId(), policy));
+		invokeAllExtensions((e, m) -> e.afterPull(m, this, this.carnotzet));
 	}
 
 	@Override
@@ -333,7 +398,9 @@ public class DockerComposeRuntime implements ContainerOrchestrationRuntime {
 	@Override
 	public void pull(@NonNull String services, PullPolicy policy) {
 		for (CarnotzetModule serviceModule : resolveModules(services)) {
+			invokeAllExtensions((e, m) -> e.beforePull(m, this, this.carnotzet), serviceModule);
 			DockerRegistry.pullImage(serviceModule, policy);
+			invokeAllExtensions((e, m) -> e.afterPull(m, this, this.carnotzet), serviceModule);
 		}
 	}
 
@@ -443,8 +510,10 @@ public class DockerComposeRuntime implements ContainerOrchestrationRuntime {
 
 	public void clean(String services) {
 		for (CarnotzetModule carnotzetModule : resolveModules(services)) {
+			invokeAllExtensions((e, m) -> e.beforeClean(m, this, this.carnotzet), carnotzetModule);
 			String service = carnotzetModule.getServiceId();
 			runCommand("docker-compose", "-p", getDockerComposeProjectName(), "rm", "-f", service);
+			invokeAllExtensions((e, m) -> e.afterClean(m, this, this.carnotzet), carnotzetModule);
 		}
 	}
 
@@ -507,5 +576,10 @@ public class DockerComposeRuntime implements ContainerOrchestrationRuntime {
 			throw new RuntimeException("service [" + services + "] not found");
 		}
 		return myModules;
+	}
+
+	@Override
+	public String getInstanceId() {
+		return instanceId;
 	}
 }

--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -36,6 +36,10 @@ docs:
       - title: "Network communication with containers"
         url: /user-guide/network-communication-with-containers
 
+
+  - title: "Extension points"
+    url: /extending-behavior/extension-points
+
 main:
   - title: "Technical blog"
     url: https://medium.com/swissquote-engineering

--- a/docs/_docs/extending-behavoir/extension-points.md
+++ b/docs/_docs/extending-behavoir/extension-points.md
@@ -1,0 +1,33 @@
+---
+title: "Extending carnotzet features"
+url: /extending-behavior/extension-points
+---
+
+{% include toc %} 
+
+## Static extension
+
+This extension points allows you to modify the applications in the environment, you can for example:
+- Add or remove applications to the environment
+- Add volume mounts to containers in the environment
+- Override the entrypoint/cmd of the container, for example to wrap the startup script of containers with custom code
+- etc...
+
+Have a look at examples in the /examples/hello-extension folder to see how it is done.
+
+## Runtime extension
+
+Sometimes, extending the definition of the environment is not enough and you need to use runtime information in your
+extensions (for example the instance id or the Ip addresses of running containers).
+
+To achieve this, there is another extension point for ContainerRuntimes which allows you to extend behavior around the
+lifecycle of containers and use the information only available at runtime.
+
+Have a look at examples in the /examples/hello-runtime-extension folder to see how it is done.
+
+
+## Enabling and configuring extensions
+
+Extensions can be enabled by adding them to the classpath or manually registering them in the CarnotzetConfig.
+When using the plugin, they can also be configured individually using the pom.xml. Have a look at the /exmaples/redis 
+carnotzet to see how.

--- a/e2e-tests/src/test/java/com/swissquote/github/carnotzet/e2e/test/RuntimeExtensionExamplesTest.java
+++ b/e2e-tests/src/test/java/com/swissquote/github/carnotzet/e2e/test/RuntimeExtensionExamplesTest.java
@@ -1,0 +1,45 @@
+package com.swissquote.github.carnotzet.e2e.test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.junit.Test;
+
+import com.github.swissquote.carnotzet.core.runtime.DefaultCommandRunner;
+
+public class RuntimeExtensionExamplesTest {
+
+	private final static Pattern IP_PATTERN = Pattern.compile("^(?:[0-9]{1,3}\\.){3}[0-9]{1,3}$");
+
+	@Test
+	public void testClassPathExtension() throws IOException {
+		try {
+			runGoal("zet:start");
+			String output = DefaultCommandRunner.INSTANCE
+					.runCommandAndCaptureOutput("docker", "ps", "-q", "--filter",
+							"label=carnotzet.runtime.hello.message=Hello Carnotzet Runtime");
+			assertFalse("The output should contain single entry for redis zet module", output.isEmpty());
+			List<String> lines = Files.readAllLines(Paths.get("/tmp/carnotzet_ip_dump/redis"));
+			assertTrue(IP_PATTERN.matcher(lines.get(0)).find());
+		}
+		finally {
+			runGoal("zet:stop");
+			runGoal("zet:clean");
+		}
+
+		assertFalse(new File("/tmp/carnotzet_ip_dump").exists());
+
+	}
+
+	private void runGoal(String goal) throws IOException {
+		DefaultCommandRunner.INSTANCE.runCommand(Paths.get("../examples/redis").toRealPath().toFile(), "mvn", goal);
+	}
+
+}

--- a/examples/hello-runtime-extension/pom.xml
+++ b/examples/hello-runtime-extension/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xmlns="http://maven.apache.org/POM/4.0.0"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<parent>
+		<artifactId>carnotzet-examples</artifactId>
+		<groupId>com.github.swissquote.examples</groupId>
+		<version>1.8.5-SNAPSHOT</version>
+	</parent>
+	<modelVersion>4.0.0</modelVersion>
+
+	<artifactId>hello-runtime-extension</artifactId>
+
+	<dependencies>
+		<dependency>
+			<groupId>com.github.swissquote</groupId>
+			<artifactId>carnotzet-core</artifactId>
+			<version>${project.parent.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.github.swissquote</groupId>
+			<artifactId>zet-maven-plugin</artifactId>
+			<version>1.8.5-SNAPSHOT</version>
+			<scope>provided</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<configuration>
+					<archive>
+						<manifestEntries>
+							<Automatic-Module-Name>com.github.swissquote.carnotzet.examples.extensions.hello</Automatic-Module-Name>
+						</manifestEntries>
+					</archive>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/examples/hello-runtime-extension/src/main/java/com/github/swissquote/carnotzet/runtime/extension/ContainerIpsDumpExtension.java
+++ b/examples/hello-runtime-extension/src/main/java/com/github/swissquote/carnotzet/runtime/extension/ContainerIpsDumpExtension.java
@@ -1,0 +1,69 @@
+package com.github.swissquote.carnotzet.runtime.extension;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.github.swissquote.carnotzet.core.Carnotzet;
+import com.github.swissquote.carnotzet.core.CarnotzetModule;
+import com.github.swissquote.carnotzet.core.runtime.api.Container;
+import com.github.swissquote.carnotzet.core.runtime.api.ContainerOrchestrationRuntime;
+import com.github.swissquote.carnotzet.core.runtime.api.ContainerOrchestrationRuntimeExtension;
+
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public final class ContainerIpsDumpExtension implements ContainerOrchestrationRuntimeExtension {
+
+	private final String message;
+	private final Path dumpDirectory;
+
+	public ContainerIpsDumpExtension(String message, Path dumpDirectory) {
+		this.message = message;
+		this.dumpDirectory = dumpDirectory;
+	}
+
+	@Override
+	public CarnotzetModule beforeStart(CarnotzetModule module, ContainerOrchestrationRuntime runtime, Carnotzet carnotzet) {
+		log.info("Before start");
+		CarnotzetModule.CarnotzetModuleBuilder result = module.toBuilder();
+		Map<String, String> labels = new HashMap<>();
+		if (module.getLabels() != null) {
+			labels.putAll(module.getLabels());
+		}
+		labels.put("carnotzet.runtime.hello.message", message);
+		result.labels(labels);
+		return result.build();
+	}
+
+	@Override
+	@SneakyThrows
+	public CarnotzetModule afterStart(CarnotzetModule module, ContainerOrchestrationRuntime runtime, Carnotzet carnotzet) {
+		log.info("After start");
+		dumpDirectory.toFile().mkdirs();
+		Container container = runtime.getContainer(module.getServiceId());
+		byte[] ipStrBytes = container.getIp().getBytes();
+		Files.write(dumpDirectory.resolve(module.getServiceId()), ipStrBytes);
+		return module;
+	}
+
+	@Override
+	public CarnotzetModule beforeStop(CarnotzetModule module, ContainerOrchestrationRuntime runtime, Carnotzet carnotzet) {
+		log.info("Before stop");
+		deleteDirectoryStream(dumpDirectory);
+		return module;
+	}
+
+	@SneakyThrows
+	void deleteDirectoryStream(Path path) {
+		Files.walk(path)
+				.sorted(Comparator.reverseOrder())
+				.map(Path::toFile)
+				.forEach(File::delete);
+	}
+
+}

--- a/examples/hello-runtime-extension/src/main/java/com/github/swissquote/carnotzet/runtime/extension/ContainerIpsDumpExtensionFactory.java
+++ b/examples/hello-runtime-extension/src/main/java/com/github/swissquote/carnotzet/runtime/extension/ContainerIpsDumpExtensionFactory.java
@@ -1,0 +1,18 @@
+package com.github.swissquote.carnotzet.runtime.extension;
+
+import java.nio.file.Paths;
+import java.util.Properties;
+
+import com.github.swissquote.carnotzet.core.runtime.api.ContainerOrchestrationRuntimeExtension;
+import com.github.swissquote.carnotzet.maven.plugin.spi.ContainerOrchestrationRuntimeExtensionsFactory;
+
+public class ContainerIpsDumpExtensionFactory implements ContainerOrchestrationRuntimeExtensionsFactory {
+
+	@Override
+	public ContainerOrchestrationRuntimeExtension create(Properties configuration) {
+		return new ContainerIpsDumpExtension(
+				configuration.getProperty("message.text", "Property not found"),
+				Paths.get(configuration.getProperty("dump.directory", "/tmp/carnotzet_ip_dump"))
+		);
+	}
+}

--- a/examples/hello-runtime-extension/src/main/resources/META-INF/services/com.github.swissquote.carnotzet.maven.plugin.spi.ContainerOrchestrationRuntimeExtensionsFactory
+++ b/examples/hello-runtime-extension/src/main/resources/META-INF/services/com.github.swissquote.carnotzet.maven.plugin.spi.ContainerOrchestrationRuntimeExtensionsFactory
@@ -1,0 +1,1 @@
+com.github.swissquote.carnotzet.runtime.extension.ContainerIpsDumpExtensionFactory

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -28,6 +28,7 @@
         <module>voting-worker</module>
         <module>voting-all</module>
         <module>hello-extension</module>
+		  <module>hello-runtime-extension</module>
     </modules>
 
 </project>

--- a/examples/redis/pom.xml
+++ b/examples/redis/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+			xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
@@ -14,11 +14,11 @@
 	<description>Example carnotzet module for redis https://redis.io/</description>
 
 	<!--<dependencies>-->
-		<!--<dependency>-->
-			<!--<groupId>com.github.swissquote.examples</groupId>-->
-			<!--<artifactId>voting-worker-carnotzet</artifactId>-->
-			<!--<version>1.5.0</version>-->
-		<!--</dependency>-->
+	<!--<dependency>-->
+	<!--<groupId>com.github.swissquote.examples</groupId>-->
+	<!--<artifactId>voting-worker-carnotzet</artifactId>-->
+	<!--<version>1.5.0</version>-->
+	<!--</dependency>-->
 	<!--</dependencies>-->
 
 	<build>
@@ -39,11 +39,27 @@
 							</properties>
 						</extension>
 					</extensions>
+					<runtimeExtensions>
+						<extension>
+							<factoryClass>com.github.swissquote.carnotzet.runtime.extension.ContainerIpsDumpExtensionFactory</factoryClass>
+							<properties>
+								<property>
+									<name>message.text</name>
+									<value>Hello Carnotzet Runtime</value>
+								</property>
+							</properties>
+						</extension>
+					</runtimeExtensions>
 				</configuration>
 				<dependencies>
 					<dependency>
 						<groupId>com.github.swissquote.examples</groupId>
 						<artifactId>hello-extension</artifactId>
+						<version>${project.parent.version}</version>
+					</dependency>
+					<dependency>
+						<groupId>com.github.swissquote.examples</groupId>
+						<artifactId>hello-runtime-extension</artifactId>
 						<version>${project.parent.version}</version>
 					</dependency>
 				</dependencies>

--- a/maven-plugin/src/main/java/com/github/swissquote/carnotzet/maven/plugin/ExtensionConfiguration.java
+++ b/maven-plugin/src/main/java/com/github/swissquote/carnotzet/maven/plugin/ExtensionConfiguration.java
@@ -2,21 +2,20 @@ package com.github.swissquote.carnotzet.maven.plugin;
 
 import java.util.Properties;
 
-import com.github.swissquote.carnotzet.maven.plugin.spi.ExtensionFactory;
-
 import lombok.Data;
 
 /**
- * Maven configuration for initializing {@link ExtensionFactory}
+ * Maven configuration for initializing {@link com.github.swissquote.carnotzet.maven.plugin.spi.ExtensionFactory}
  */
 @Data
 public class ExtensionConfiguration {
 	/**
-	 * The class name of the {@link ExtensionFactory} instance to be configured using provided properties
+	 * The class name of the {@link com.github.swissquote.carnotzet.maven.plugin.spi.ExtensionFactory} instance to be configured using provided
+	 * properties
 	 */
 	private String factoryClass;
 	/**
-	 * Properties to be used for {@link ExtensionFactory} configuration
+	 * Properties to be used for {@link com.github.swissquote.carnotzet.maven.plugin.spi.ExtensionFactory} configuration
 	 */
 	private Properties properties;
 

--- a/maven-plugin/src/main/java/com/github/swissquote/carnotzet/maven/plugin/ExtensionConfiguration.java
+++ b/maven-plugin/src/main/java/com/github/swissquote/carnotzet/maven/plugin/ExtensionConfiguration.java
@@ -2,26 +2,25 @@ package com.github.swissquote.carnotzet.maven.plugin;
 
 import java.util.Properties;
 
-import com.github.swissquote.carnotzet.maven.plugin.spi.CarnotzetExtensionsFactory;
+import com.github.swissquote.carnotzet.maven.plugin.spi.ExtensionFactory;
 
 import lombok.Data;
 
 /**
- * Maven configuration for initializing {@link com.github.swissquote.carnotzet.core.CarnotzetExtension}
+ * Maven configuration for initializing {@link ExtensionFactory}
  */
 @Data
 public class ExtensionConfiguration {
 	/**
-	 * The class name of the {@link com.github.swissquote.carnotzet.maven.plugin.spi.CarnotzetExtensionsFactory} instance to be configured using
-	 * provided properties
+	 * The class name of the {@link ExtensionFactory} instance to be configured using provided properties
 	 */
 	private String factoryClass;
 	/**
-	 * Properties to be used for {@link CarnotzetExtensionsFactory} configuration
+	 * Properties to be used for {@link ExtensionFactory} configuration
 	 */
 	private Properties properties;
 
-	public boolean isFor(Class<? extends CarnotzetExtensionsFactory> extFactoryClass) {
+	public <F> boolean isFor(Class<F> extFactoryClass) {
 		return extFactoryClass.getName().equalsIgnoreCase(factoryClass);
 	}
 }

--- a/maven-plugin/src/main/java/com/github/swissquote/carnotzet/maven/plugin/spi/CarnotzetExtensionsFactory.java
+++ b/maven-plugin/src/main/java/com/github/swissquote/carnotzet/maven/plugin/spi/CarnotzetExtensionsFactory.java
@@ -1,12 +1,9 @@
 package com.github.swissquote.carnotzet.maven.plugin.spi;
 
-import java.util.Properties;
-
 import com.github.swissquote.carnotzet.core.CarnotzetExtension;
 
 /**
  * The interface for creating and initializing {@link CarnotzetExtension} particular instance
  */
-public interface CarnotzetExtensionsFactory {
-	CarnotzetExtension create(Properties configuration);
+public interface CarnotzetExtensionsFactory extends ExtensionFactory<CarnotzetExtension> {
 }

--- a/maven-plugin/src/main/java/com/github/swissquote/carnotzet/maven/plugin/spi/ContainerOrchestrationRuntimeExtensionsFactory.java
+++ b/maven-plugin/src/main/java/com/github/swissquote/carnotzet/maven/plugin/spi/ContainerOrchestrationRuntimeExtensionsFactory.java
@@ -1,0 +1,10 @@
+package com.github.swissquote.carnotzet.maven.plugin.spi;
+
+import com.github.swissquote.carnotzet.core.runtime.api.ContainerOrchestrationRuntimeExtension;
+
+/**
+ * The interface for creating and initializing {@link com.github.swissquote.carnotzet.core.runtime.api.ContainerOrchestrationRuntimeExtension}
+ * instance
+ */
+public interface ContainerOrchestrationRuntimeExtensionsFactory extends ExtensionFactory<ContainerOrchestrationRuntimeExtension> {
+}

--- a/maven-plugin/src/main/java/com/github/swissquote/carnotzet/maven/plugin/spi/ExtensionFactory.java
+++ b/maven-plugin/src/main/java/com/github/swissquote/carnotzet/maven/plugin/spi/ExtensionFactory.java
@@ -1,0 +1,7 @@
+package com.github.swissquote.carnotzet.maven.plugin.spi;
+
+import java.util.Properties;
+
+public interface ExtensionFactory<E> {
+	E create(Properties configuration);
+}

--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,7 @@
 						</execution>
 					</executions>
 					<configuration>
+						<doclint>none</doclint>
 						<source>8</source>
 					</configuration>
 				</plugin>


### PR DESCRIPTION
Here are some potential use cases for this:

- Cleanup some "extension managed" resources when the environment is cleaned
- Use runtime information inside extensions (instanceId, ip addresses, etc...)
- Programaticaly change the ENTRYPOINT/CMD of a container just before it starts (for example to pass command line arguments in e2e tests or when manually starting a container in the environment)