### PR TITLE
Add hostname as label for docker-compose

### DIFF
--- a/docker-compose/src/main/java/com/github/swissquote/carnotzet/runtime/docker/compose/DockerComposeRuntime.java
+++ b/docker-compose/src/main/java/com/github/swissquote/carnotzet/runtime/docker/compose/DockerComposeRuntime.java
@@ -5,6 +5,8 @@ import static java.util.stream.Collectors.toList;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -154,6 +156,15 @@ public class DockerComposeRuntime implements ContainerOrchestrationRuntime {
 			if (module.getLabels() != null) {
 				labels.putAll(module.getLabels());
 			}
+
+			try {
+				String hostname = InetAddress.getLocalHost().getHostName();
+				labels.put("carnotzet.instance.source", hostname);
+			}
+			catch (UnknownHostException e) {
+				log.error("Cannot determine hostname", e);
+			}
+
 			labels.put("com.dnsdock.alias", networkAliases.stream().collect(Collectors.joining(",")));
 			labels.put("carnotzet.instance.id", instanceId);
 			labels.put("carnotzet.module.name", module.getName());


### PR DESCRIPTION
Hi,

I'm proposing this change to help implement cleanup policies in the build farm sentinel.

The idea here is that when checking if a sandbox should be deleted we can do a simple if `carnotzet.instance.source`'s value corresponds to no running build pod : we can delete the sandbox.