### PR TITLE
SWEP-415: make network docker-compose unique 

### DIFF
--- a/core/src/main/java/com/github/swissquote/carnotzet/core/util/Sha256.java
+++ b/core/src/main/java/com/github/swissquote/carnotzet/core/util/Sha256.java
@@ -1,0 +1,39 @@
+package com.github.swissquote.carnotzet.core.util;
+
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+
+import lombok.SneakyThrows;
+
+public class Sha256 {
+	public static final int RADIX = 16;
+	public static final int PAD = 32;
+	public static final String ALGORITHM = "SHA-256";
+
+	private Sha256() {
+	}
+
+
+	@SneakyThrows
+	public static String getSHA(String input) {
+		// Static getInstance method is called with hashing SHA
+		MessageDigest md = MessageDigest.getInstance(ALGORITHM);
+		// digest() method called
+		// to calculate message digest of an input
+		// and return array of byte
+		return toHexString(md.digest(input.getBytes(StandardCharsets.UTF_8)));
+	}
+
+	private static String toHexString(byte[] hash) {
+		// Convert byte array into signum representation
+		BigInteger number = new BigInteger(1, hash);
+		// Convert message digest into hex value
+		StringBuilder hexString = new StringBuilder(number.toString(RADIX));
+		// Pad with leading zeros
+		while (hexString.length() < PAD) {
+			hexString.insert(0, '0');
+		}
+		return hexString.toString();
+	}
+}

--- a/core/src/main/java/com/github/swissquote/carnotzet/core/util/Sha256.java
+++ b/core/src/main/java/com/github/swissquote/carnotzet/core/util/Sha256.java
@@ -6,7 +6,7 @@ import java.security.MessageDigest;
 
 import lombok.SneakyThrows;
 
-public class Sha256 {
+public final class Sha256 {
 	public static final int RADIX = 16;
 	public static final int PAD = 32;
 	public static final String ALGORITHM = "SHA-256";

--- a/docker-compose/src/main/java/com/github/swissquote/carnotzet/runtime/docker/compose/DockerComposeRuntime.java
+++ b/docker-compose/src/main/java/com/github/swissquote/carnotzet/runtime/docker/compose/DockerComposeRuntime.java
@@ -344,7 +344,7 @@ public class DockerComposeRuntime implements ContainerOrchestrationRuntime {
 	}
 
 	private String genNetworkName() {
-		// SWEP-415: we use only first 12 character, 48-bit pre-hash which has collision chance 1 of out of 10M
+		// We use only first 12 characters of sha256 (48-bit) which has collision chance 1 of out of 10M
 		return "carnotzet_" + Sha256.getSHA(carnotzet.getResourcesFolder().toString()).substring(0, 12);
 	}
 

--- a/docker-compose/src/main/java/com/github/swissquote/carnotzet/runtime/docker/compose/DockerComposeRuntime.java
+++ b/docker-compose/src/main/java/com/github/swissquote/carnotzet/runtime/docker/compose/DockerComposeRuntime.java
@@ -45,6 +45,7 @@ import com.github.swissquote.carnotzet.core.runtime.api.ExecResult;
 import com.github.swissquote.carnotzet.core.runtime.api.PullPolicy;
 import com.github.swissquote.carnotzet.core.runtime.log.LogListener;
 import com.github.swissquote.carnotzet.core.runtime.spi.ContainerOrchestrationRuntimeDefaultExtensionsProvider;
+import com.github.swissquote.carnotzet.core.util.Sha256;
 import com.google.common.base.Strings;
 import com.google.common.io.Files;
 
@@ -149,7 +150,7 @@ public class DockerComposeRuntime implements ContainerOrchestrationRuntime {
 			}
 
 			ContainerNetwork network = ContainerNetwork.builder().aliases(networkAliases).build();
-			networks.put("carnotzet", network);
+			networks.put(genNetworkName(), network);
 			serviceBuilder.networks(networks);
 
 			Map<String, String> labels = new HashMap<>();
@@ -179,7 +180,7 @@ public class DockerComposeRuntime implements ContainerOrchestrationRuntime {
 
 		Network network = Network.builder().driver("bridge").build();
 		Map<String, Network> networks = new HashMap<>();
-		networks.put("carnotzet", network);
+		networks.put(genNetworkName(), network);
 
 		DockerCompose compose = DockerCompose.builder().version("2").services(services).networks(networks).build();
 		DockerComposeGenerator generator = new DockerComposeGenerator(compose);
@@ -339,7 +340,12 @@ public class DockerComposeRuntime implements ContainerOrchestrationRuntime {
 	}
 
 	private String getDockerNetworkName() {
-		return getDockerComposeProjectName() + "_carnotzet";
+		return getDockerComposeProjectName() + "_" + genNetworkName();
+	}
+
+	private String genNetworkName() {
+		// SWEP-415: we use only first 12 character, 48-bit pre-hash which has collision chance 1 of out of 10M
+		return "carnotzet_" + Sha256.getSHA(carnotzet.getResourcesFolder().toString()).substring(0, 12);
 	}
 
 	// normalize docker compose project name the same way docker-compose does (see https://github.com/docker/compose/tree/master/compose)


### PR DESCRIPTION
We make network docker-compose unique by using sha256 of docker-compose file path when generating network name. 
The reason is to avoid 2 jenkins builds of the same project (e.g. 2 PRs) can have network collision.  

Avoid network name is too long with full sha256 --> take only 48-bit hash prefix (first 12 characters) of sha256 digest 
https://www.bluebill.net/hash_collisions.html
https://developers.google.com/safe-browsing/v4/urls-hashing